### PR TITLE
CoreRules doc pass + expression-bodied member pass

### DIFF
--- a/src/tbrpg.Controllers/GameManager.cs
+++ b/src/tbrpg.Controllers/GameManager.cs
@@ -28,6 +28,11 @@ namespace tbrpg.Controllers
         public event EventHandler AdventureSaved;
 
         /// <summary>
+        /// Event raised when the <see cref="ActiveAdventure"/> is started.
+        /// </summary>
+        public event EventHandler AdventureStarted;
+
+        /// <summary>
         /// Creates a new instance of the GameManager class.
         /// </summary>
         /// <remarks>Private constructor to enforce singleton usage via the <see cref="GameManager.Instance"/> property.</remarks>
@@ -46,8 +51,8 @@ namespace tbrpg.Controllers
         /// Loads the specified <see cref="Adventure"/> into the GameManager, and sets it as the <see cref="ActiveAdventure"/>.
         /// </summary>
         /// <param name="saveType">The type of save/load operation.</param>
-        /// <param name="adventureId">The path or URL to the <see cref="Adventure"/> to load.</param>
-        /// <returns>Value indicating whether the operation was successful.</returns>
+        /// <param name="path">The path or URL to the <see cref="Adventure"/> to load.</param>
+        /// <returns>Whether the operation was successful.</returns>
         public bool LoadAdventure(SaveType saveType, string path)
         {
             bool loaded = true;
@@ -93,8 +98,8 @@ namespace tbrpg.Controllers
         /// Saves the <see cref="ActiveAdventure"/> to the specified storage location.
         /// </summary>
         /// <param name="saveType">The type of save/load operation.</param>
-        /// <param name="adventureId">The path or URL to which to save the <see cref="Adventure"/>.</param>
-        /// <returns>Value indicating whether the operation was successful.</returns>
+        /// <param name="path">The path or URL to which to save the <see cref="Adventure"/>.</param>
+        /// <returns>Whether the operation was successful.</returns>
         public bool SaveActiveAdventure(SaveType saveType, string path)
         {
             bool saved = true;
@@ -137,13 +142,21 @@ namespace tbrpg.Controllers
         }
 
         /// <summary>
+        /// Raises the <see cref="AdventureSaved"/> event.
+        /// </summary>
+        private void OnAdventureStarted()
+        {
+            this.AdventureStarted?.Invoke(this, new EventArgs());
+        }
+
+        /// <summary>
         /// Starts the active <see cref="Adventure"/>.
         /// </summary>
         public void StartAdventure()
         {
             if (this.ActiveAdventure != null)
             {
-                Console.WriteLine("Adventure started.");
+                OnAdventureStarted();
             }
             else
             {

--- a/src/tbrpg.CoreRules/Ability.cs
+++ b/src/tbrpg.CoreRules/Ability.cs
@@ -1,13 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace tbrpg.CoreRules
 {
     /// <summary>
     /// A Being has one or more Abilities. An Ability is used when performing checks to
-    /// test success of a GameAction as well as to modify DiceRolls via the Ability's Mods.
+    /// test success of a GameAction as well as to modify DiceRolls via the Ability's Modifiers.
     /// </summary>
     public class Ability
     {
@@ -29,9 +27,6 @@ namespace tbrpg.CoreRules
         /// <summary>
         /// Gets the total value of this ability - the BaseValue plus its <see cref="Modifiers"/>.
         /// </summary>
-        public int Value
-        {
-            get { return BaseValue + Modifiers.Select(m => m.ModifierValue).Aggregate((x, y) => x + y); }
-        }
+        public int Value => BaseValue + Modifiers.Select(m => m.ModifierValue).Aggregate((x, y) => x + y);
     }
 }

--- a/src/tbrpg.CoreRules/AbilityModifier.cs
+++ b/src/tbrpg.CoreRules/AbilityModifier.cs
@@ -25,14 +25,8 @@ namespace tbrpg.CoreRules
         public int ModifierValue { get; set; }
 
         /// <summary>
-        /// Gets a value indicating whether the Modifier is configured with both a source and value.
+        /// Gets whether the Modifier is configured with both a source and value.
         /// </summary>
-        public bool IsValid
-        {
-            get
-            {
-                return (ModifierSource != null && (ModifierValue >= 0 || ModifierValue <= 0));
-            }
-        }
+        public bool IsValid => ModifierSource != null && (ModifierValue >= 0 || ModifierValue <= 0);
     }
 }

--- a/src/tbrpg.CoreRules/Adventure.cs
+++ b/src/tbrpg.CoreRules/Adventure.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace tbrpg.CoreRules
 {
     /// <summary>
-    /// The Adventure contains one or more <see cref="Dungeon"/> and <see cref="Quest"/> objects.
+    /// An Adventure contains one or more <see cref="Dungeon"/> and <see cref="Quest"/> objects.
     /// </summary>
     public class Adventure
     {
@@ -12,11 +11,6 @@ namespace tbrpg.CoreRules
         /// Gets or sets the active player <see cref="Party"/>.
         /// </summary>
         public Party ActiveParty { get; set; }
-
-        /// <summary>
-        /// Gets or sets the ID of the <see cref="Dungeon"/> currently being explored by the player's <see cref="Party"/>.
-        /// </summary>
-        public string ActiveDungeonId { get; set; }
 
         /// <summary>
         /// Gets the active <see cref="Dungeon"/>.
@@ -36,7 +30,7 @@ namespace tbrpg.CoreRules
         /// <summary>
         /// Adds the specified <see cref="Dungeon"/> to the Adventure.
         /// </summary>
-        /// <param name="dungeon"></param>
+        /// <param name="dungeon">The <see cref="Dungeon"/> to add to the Adventure.</param>
         public void AddDungeon(Dungeon dungeon)
         {
             this.Dungeons.Add(dungeon);
@@ -49,7 +43,6 @@ namespace tbrpg.CoreRules
         public void SetActiveDungeon(Dungeon dungeon)
         {
             this.ActiveDungeon = dungeon;
-            this.ActiveDungeonId = dungeon.DungeonId;
         }
 
         /// <summary>

--- a/src/tbrpg.CoreRules/Alignment.cs
+++ b/src/tbrpg.CoreRules/Alignment.cs
@@ -5,10 +5,10 @@
     /// </summary>
     public enum Alignment
     {
-        LawfulGood,  //Civilization and order.
-        Good,        //Freedom and kindness.
-        Evil,        //Tyranny and hatred.
-        ChaoticEvil, //Entropy and destruction.
-        Unaligned    //Having no alignment; not taking a stand.
+        LawfulGood,  // Civilization and order.
+        Good,        // Freedom and kindness.
+        Evil,        // Tyranny and hatred.
+        ChaoticEvil, // Entropy and destruction.
+        Unaligned    // Having no alignment; not taking a stand.
     }
 }

--- a/src/tbrpg.CoreRules/Being.cs
+++ b/src/tbrpg.CoreRules/Being.cs
@@ -13,7 +13,7 @@ namespace tbrpg.CoreRules
         private DiceRoll _attackRoll = new DiceRoll("1d20");
 
         /// <summary>
-        /// Event raised when the Being's HitPoints hit zero or below.
+        /// Event raised when the Being's HitPoints reach zero or below.
         /// </summary>
         public event EventHandler Killed;
 
@@ -73,15 +73,12 @@ namespace tbrpg.CoreRules
         public int ExperiencePoints { get; set; }
 
         /// <summary>
-        /// Gets a value indicating whether this Being is alive (has greater than zero hit points).
+        /// Gets whether this Being is alive (has greater than zero hit points).
         /// </summary>
-        public bool IsAlive
-        {
-            get { return (HitPoints > 0); }
-        }
+        public bool IsAlive => HitPoints > 0;
 
         /// <summary>
-        /// Gets or sets a value indicating whether this Being can be attacked.
+        /// Gets or sets whether this Being can be attacked.
         /// </summary>
         public bool IsTargetable { get; set; }
 
@@ -91,32 +88,31 @@ namespace tbrpg.CoreRules
         public IGameItem ActiveItem { get; set; } =
             new Weapon
             {
-                Name = "Hands",
+                Name = "Fist",
                 Description = "Default weapon.",
                 DamageDie = "1d2",
                 NumberOfAttacks = 1
             };
 
         /// <summary>
-        /// Gets or sets a value specifying the minimum attack roll needed to hit the GamePiece.
+        /// Gets or sets the minimum attack roll needed to hit the GamePiece.
         /// </summary>
         public int Defense { get; set; } //TODO: Defense to take into account armor and all modifiers such as magic items or enchantments/spells.
 
         /// <summary>
         /// Gets the list of targets from which this Being can select one or more targets before calling <see cref="PerformActionOnSelectedTargets"/>.
         /// </summary>
-        /// <remarks>You cannot populate this list directly; use <see cref="AddPotentialTargets(List{Being})"/> instead.</remarks>
-        public ReadOnlyCollection<Being> PotentialTargets
-        {
-            get { return _potentialTargets.AsReadOnly(); }
-        }
+        /// <remarks>You can't populate this list directly. Use <see cref="AddPotentialTargets(List{Being})"/> instead.</remarks>
+        public ReadOnlyCollection<Being> PotentialTargets => _potentialTargets.AsReadOnly();
+
         private List<Being> _potentialTargets = new List<Being>();
 
         /// <summary>
         /// Gets the list of targets that the Being has selected for its next <see cref="GameAction"/>.
-        /// Populate this list by calling <see cref="AddSelectedTarget"/>, then call <see cref="DoActionOnSelectedTargets"/>
-        /// to perform <see cref="GameAction"/>s on with the active <see cref="IGameItem"/> on the selected targets.
         /// </summary>
+        /// <remarks>You can't populate this list directly. Use <see cref="AddSelectedTarget"/>, then call <see cref="PerformActionOnSelectedTargets"/>
+        /// to perform <see cref="GameAction"/>s on the targets in the collection with this Being's <see cref="ActiveItem"/>.
+        /// </remarks>
         public ReadOnlyCollection<Being> SelectedTargets
         {
             get { return _selectedTargets.AsReadOnly(); }
@@ -150,7 +146,7 @@ namespace tbrpg.CoreRules
         /// Deducts the specified amount of HitPoints from the Being.
         /// </summary>
         /// <param name="damage">The amount of HitPoints to deduct.</param>
-        /// <returns>Value indicating whether the applied damage killed the being.</returns>
+        /// <returns>Whether the applied damage killed the being.</returns>
         /// <remarks>If the Being is killed by this damage, the <see cref="OnBeingKilled"/> event is raised.
         /// The event is only raised if the Being was previously alive. This method will return <c>true</c>
         /// only if the Being was alive prior to taking this damage.</remarks>
@@ -199,7 +195,7 @@ namespace tbrpg.CoreRules
         /// <summary>
         /// For each <see cref="Being"/> in <see cref="SelectedTargets"/>, creates and performs a <see cref="GameAction"/>.
         /// </summary>
-        /// <remarks>Call this after the <see cref="SelectedTargets"/> collection has been populated.</remarks>
+        /// <remarks>Call this after the <see cref="SelectedTargets"/> collection has been populated with <see cref="AddSelectedTarget">.</remarks>
         public void PerformActionOnSelectedTargets()
         {
             foreach (Being target in this.SelectedTargets)
@@ -209,18 +205,16 @@ namespace tbrpg.CoreRules
             }
         }
 
-        public override string ToString()
-        {
-            return String.Format($"{this.Name} ({this.HitPoints}/{this.MaxHitPoints})");
-        }
+        public override string ToString() => String.Format($"{this.Name} ({this.HitPoints}/{this.MaxHitPoints})");
+
         #endregion
 
         /// <summary>
         /// Adds the specified target Beings to the collection of potential targets for this Being.
         /// </summary>
         /// <param name="targets"></param>
-        /// <remarks>Reference <see cref="SelectedTargets"/> to obtain a list of Beings that this Being can target with
-        /// its active <see cref="IGameItem"/>.</remarks>
+        /// <remarks>Reference <see cref="PotentialTargets"/> to obtain a list of Beings that this Being can target with
+        /// its <see cref="ActiveItem"/>.</remarks>
         internal void AddPotentialTargets(List<Being> targets)
         {
             _selectedTargets.Clear();
@@ -262,20 +256,11 @@ namespace tbrpg.CoreRules
         /// <summary>
         /// Raises the <see cref="PotentialTargetsAdded"/> event.
         /// </summary>
-        private void OnPotentialTargetsAdded()
-        {
-            PotentialTargetsAdded?.Invoke(this, new EventArgs());
-        }
+        private void OnPotentialTargetsAdded() => PotentialTargetsAdded?.Invoke(this, new EventArgs());
 
         /// <summary>
         /// Raises the <see cref="BeingKilled"/> event, signifying that the Being was just killed.
         /// </summary>
-        private void OnKilled()
-        {
-            Killed?.Invoke(this, new EventArgs());
-        }
-
-
-
+        private void OnKilled() => Killed?.Invoke(this, new EventArgs());
     }
 }

--- a/src/tbrpg.CoreRules/Dungeon.cs
+++ b/src/tbrpg.CoreRules/Dungeon.cs
@@ -17,22 +17,22 @@ namespace tbrpg.CoreRules
         public event EventHandler Encountered;
 
         /// <summary>
-        /// Gets or sets the width of the Dungeon. The default value is 15.
+        /// Gets or sets the width of the Dungeon. Default: <c>15</c>.
         /// </summary>
         public int Width { get; set; } = 15;
 
         /// <summary>
-        /// Gets or sets the height of the dungeon. The default value is 15.
+        /// Gets or sets the height of the dungeon. Default: <c>15</c>.
         /// </summary>
         public int Height { get; set; } = 15;
 
         /// <summary>
-        /// Gets or sets the starting position of the <see cref="Party"/>. The default is 0,0.
+        /// Gets or sets the starting position of the <see cref="Party"/>. Default: <c>0,0</c>.
         /// </summary>
         public GamePosition StartPosition { get; set; } = new GamePosition(0, 0);
 
         /// <summary>
-        /// Gets or sets the current <see cref="GamePosition"/> of the <see cref="Party"/> within the Dungeon. The default is 0,0.
+        /// Gets or sets the current <see cref="GamePosition"/> of the <see cref="Party"/> within the Dungeon. Default: <c>0,0</c>.
         /// </summary>
         public GamePosition CurrentPosition { get; set; } = new GamePosition(0, 0);
 
@@ -80,10 +80,7 @@ namespace tbrpg.CoreRules
         /// Raises the event signifying that the <see cref="Party"/> has moved to a <see cref="GamePosition"/>
         /// that is occupied by an <see cref="Encounter"/>.
         /// </summary>
-        private void OnEncountered()
-        {
-            Encountered?.Invoke(this, new EventArgs());
-        }
+        private void OnEncountered() => Encountered?.Invoke(this, new EventArgs());
 
         /// <summary>
         /// Gets or sets the active <see cref="Encounter"/>.

--- a/src/tbrpg.CoreRules/Encounter.cs
+++ b/src/tbrpg.CoreRules/Encounter.cs
@@ -48,12 +48,12 @@ namespace tbrpg.CoreRules
         public Party AdventuringParty { get; private set; }
 
         /// <summary>
-        /// Gets a value indicating whether this Encounter has been started.
+        /// Gets whether this Encounter has been started.
         /// </summary>
         public bool IsEncounterStarted { get; private set; }
 
         /// <summary>
-        /// Gets a value indicating whether this Encounter has been completed.
+        /// Gets whether this Encounter has been completed.
         /// </summary>
         public bool IsEncounterEnded { get; private set; }
 
@@ -67,7 +67,7 @@ namespace tbrpg.CoreRules
         /// Adds the specified <see cref="Party"/> of adventurers that will perform GameActions on the <see cref="EncounterParty"/>.
         /// </summary>
         /// <param name="adventurers">The <see cref="Party"/> of adventurers to act upon the <see cref="EncounterParty"/> in this <see cref="Encounter"/>.</param>
-        /// <param name="startEncounter">Specifies whether the Encounter should be started immediately upon adding the adventuring party. The default is <c>false</c>.</param>
+        /// <param name="startEncounter">Specifies whether the Encounter should be started immediately upon adding the adventuring party. Default: <c>false</c>.</param>
         public void SetAdventuringParty(Party adventurers, bool startEncounter = false)
         {
             if (this.AdventuringParty == null)
@@ -199,7 +199,7 @@ namespace tbrpg.CoreRules
         /// </summary>
         private void FillAttackQueue()
         {
-            // TODO: Fill the Encounter _attackQueue in order of initiative (right now it just fills in order of characters 0 to x, then monsters 0 to x)
+            // TODO: Fill the Encounter _attackQueue in order of initiative (right now it just fills in order of characters 0 to N, then monsters 0 to N)
 
             foreach (Being adventurer in this.AdventuringParty.LivingMembers)
             {
@@ -215,10 +215,7 @@ namespace tbrpg.CoreRules
         /// <summary>
         /// Raises the <see cref="EncounterStarted"/> event.
         /// </summary>
-        private void OnEncounterStarted()
-        {
-            EncounterStarted?.Invoke(this, new EventArgs());
-        }
+        private void OnEncounterStarted() => EncounterStarted?.Invoke(this, new EventArgs());
 
         /// <summary>
         /// Raises the <see cref="EncounterEnded"/> event.
@@ -231,7 +228,7 @@ namespace tbrpg.CoreRules
         }
 
         /// <summary>
-        /// Fills the attack queues, creates GameActions for each matchup, executes those GameActions,
+        /// Fills the attack queues, creates GameActions for each matchup, executes those GameActions, and
         /// resolves the encounter if one of the parties has been defeated.
         /// </summary>
         internal void PerformAutoBattle()

--- a/src/tbrpg.CoreRules/GameAction.cs
+++ b/src/tbrpg.CoreRules/GameAction.cs
@@ -46,7 +46,7 @@ namespace tbrpg.CoreRules
         public IGamePiece Victor { get; private set; }
 
         /// <summary>
-        /// Peforms the <see cref="GameAction"/> by applying the attacker's attack roll to the defender's defense value.
+        /// Performs the <see cref="GameAction"/> by applying the attacker's attack roll to the defender's defense value.
         /// </summary>
         /// <returns>The victor in the GameAction.</returns>
         /// <remarks>The victor in the GameAction can be the defending GamePiece.</remarks>
@@ -81,17 +81,11 @@ namespace tbrpg.CoreRules
         /// <summary>
         /// Raises the <see cref="ActionPerformed"/> event, signifying that this action was just performed.
         /// </summary>
-        private void OnActionPerformed()
-        {
-            ActionPerformed?.Invoke(this, new EventArgs());
-        }
+        private void OnActionPerformed() => ActionPerformed?.Invoke(this, new EventArgs());
 
         /// <summary>
         /// Raises the <see cref="PerformingAction"/> event, signifying that this action is about to be performed.
         /// </summary>
-        private void OnPerformingAction()
-        {
-            PerformingAction?.Invoke(this, new EventArgs());
-        }
+        private void OnPerformingAction() => PerformingAction?.Invoke(this, new EventArgs());
     }
 }

--- a/src/tbrpg.CoreRules/IGamePiece.cs
+++ b/src/tbrpg.CoreRules/IGamePiece.cs
@@ -13,7 +13,7 @@
         string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the GamePiece can be the target of an attack.
+        /// Gets or sets whether the GamePiece can be the target of an attack.
         /// </summary>
         bool IsTargetable { get; set; }
 
@@ -28,7 +28,7 @@
         int MaxHitPoints { get; set; }
 
         /// <summary>
-        /// Gets or sets a value specifying the minimum attack roll needed to hit the GamePiece.
+        /// Gets or sets the minimum attack roll needed to hit the GamePiece.
         /// </summary>
         int Defense { get; set; }
 
@@ -48,7 +48,7 @@
         /// Applies the specified amount of damage to this GamePiece.
         /// </summary>
         /// <param name="damage">The amount of damage to apply.</param>
-        /// <returns>Value indicating whether the GamePiece was killed.</returns>
+        /// <returns>Whether the GamePiece was killed.</returns>
         bool ApplyDamage(int damage);
     }
 }

--- a/src/tbrpg.CoreRules/Party.cs
+++ b/src/tbrpg.CoreRules/Party.cs
@@ -73,7 +73,7 @@ namespace tbrpg.CoreRules
         /// Gets a string showing each party member and their health status.
         /// </summary>
         /// <param name="beings">A collection of party members.</param>
-        /// <returns>String showing the list of party members and their health state (remaining hit points, or "DEAD").</returns>
+        /// <returns>String showing the list of party members and their remaining hit points (or "DEAD").</returns>
         private static string GetPartyString(List<Being> beings)
         {
             StringBuilder sb = new StringBuilder();
@@ -89,10 +89,8 @@ namespace tbrpg.CoreRules
             return sb.ToString();
         }
 
-        public override string ToString()
-        {
-            return GetPartyString(_partyMembers);
-        }
+        public override string ToString() => GetPartyString(_partyMembers);
+
         #endregion
 
         /// <summary>
@@ -113,10 +111,7 @@ namespace tbrpg.CoreRules
         /// Raises the <see cref="Defeated"/> event, notifying subscribers that the last living
         /// <see cref="Being"/> in this party was <see cref="Being.Killed"/>.
         /// </summary>
-        private void OnDefeated()
-        {
-            Defeated?.Invoke(this, new EventArgs());
-        }
+        private void OnDefeated() => Defeated?.Invoke(this, new EventArgs());
 
         #region Public Properties
 
@@ -126,31 +121,19 @@ namespace tbrpg.CoreRules
         public User UserId { get; set; }
 
         /// <summary>
-        /// Gets a value indicating whether at least one member of this Party is alive. If there are no
+        /// Gets whether at least one member of this Party is alive. If there are no
         /// Beings alive in a Party, the Party is considered dead.
         /// </summary>
-        public bool IsAlive
-        {
-            get
-            {
-                return this.LivingMembers.Any();
-            }
-        }
+        public bool IsAlive => this.LivingMembers.Any();
 
         /// <summary>
         /// Gets a collection of all Beings in this party, living or otherwise.
         /// </summary>
         /// <remarks>To add or remove party members, use <see cref="AddPartyMember(Being)"/> and <see cref="RemovePartyMember(Being)"/>.</remarks>
-        public List<Being> Members
-        {
-            get
-            {
-                return _partyMembers;
-            }
-        }
+        public List<Being> Members => _partyMembers;
 
         /// <summary>
-        /// Gets a collection of all Beings in this party, living or otherwise.
+        /// Gets a collection of Beings in this party that are alive.
         /// </summary>
         /// <remarks>To add or remove party members, use <see cref="AddPartyMember(Being)"/> and <see cref="RemovePartyMember(Being)"/>.</remarks>
         public ReadOnlyCollection<Being> LivingMembers

--- a/src/tbrpg.CoreRules/Weapon.cs
+++ b/src/tbrpg.CoreRules/Weapon.cs
@@ -15,12 +15,12 @@ namespace tbrpg.CoreRules
         public string Description { get; set; } = "This is a generic weapon.";
 
         /// <summary>
-        /// The die code for the weapon. The default is "1d6".
+        /// The die code for the weapon. Default: <c>1d6</c>.
         /// </summary>
         public string DamageDie { get; set; } = "1d6";
 
         /// <summary>
-        /// The number of targets <see cref="IGamePiece"/>s this weapon can attack in one round. The default is 1.
+        /// The number of targets <see cref="IGamePiece"/>s this weapon can attack in one round. Default: <c>1</c>.
         /// </summary>
         public int NumberOfAttacks { get; set; } = 1;
 
@@ -37,11 +37,9 @@ namespace tbrpg.CoreRules
 
             return _damageRoll.RollDice();
         }
+
         private DiceRoll _damageRoll;
 
-        public override string ToString()
-        {
-            return this.Name;
-        }
+        public override string ToString() => this.Name;
     }
 }

--- a/src/tbrpg.Dice/Dice.cs
+++ b/src/tbrpg.Dice/Dice.cs
@@ -109,7 +109,7 @@ namespace tbrpg.Dice
         /// <param name="dieCode">The string containing the Die code.</param>
         /// <param name="dieCount">The Die count parameter to be populated.</param>
         /// <param name="dieSides">The number of sides per Die parameter to be populated.</param>
-        /// <returns>Value indicating whether the Die code was parsed successfully. A value of true indicates two
+        /// <returns>Whether the Die code was parsed successfully. A value of true indicates two
         /// values - both greater than 0 - were obtained.</returns>
         internal static bool TryParseDieCode(string dieCode, out int dieCount, out int dieSides)
         {

--- a/src/tbrpg.Dice/DiceHand.cs
+++ b/src/tbrpg.Dice/DiceHand.cs
@@ -28,8 +28,8 @@ namespace tbrpg.Dice
         /// <summary>
         /// Creates a new instance of DiceHand, appropriate for passing to the Dice and DiceRoll constructor.
         /// </summary>
-        /// <param name="count">The number of Dice in the DiceHand - the first value in the '#d#' format (e.g. "1d4", "2d6").</param>
-        /// <param name="sides">The number of sides per Die in the DiceHand - the second value in the '#d#' format (e.g. "1d4", "2d6").</param>
+        /// <param name="count">The number of Dice in the DiceHand - the first value in the '#d#' format (e.g. the 2 in 2d6).</param>
+        /// <param name="sides">The number of sides per Die in the DiceHand - the second value in the '#d#' format (e.g. the 6 in 2d6).</param>
         public DiceHand(int count, int sides)
         {
             //Perform some validity checks to ensure the count and sides params are at least 0.

--- a/src/tbrpg.Dice/Die.cs
+++ b/src/tbrpg.Dice/Die.cs
@@ -76,7 +76,7 @@ namespace tbrpg.Dice
         }
 
         /// <summary>
-        /// Sets the minimum value for the Die. This value must be equal to or greater than 0. The default is 1.
+        /// Sets the minimum value for the Die. This value must be equal to or greater than 0. Default: 1.
         /// </summary>
         /// <param name="minValue">The minimum int value of the Die, typically 1.</param>
         internal void SetMinimumValue(int minValue)

--- a/src/tbrpg.SaveLoad/tbrpg.SaveLoad.csproj
+++ b/src/tbrpg.SaveLoad/tbrpg.SaveLoad.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
**tbrpg.CoreRules** pass on:

- XML comments
- use expression-bodied members for one-liner public properties and event raising methods (`OnFoo()`) 