### PR TITLE
modernization + cleanup 02

### DIFF
--- a/src/tbrpg.Controllers/GameManager.cs
+++ b/src/tbrpg.Controllers/GameManager.cs
@@ -89,10 +89,7 @@ namespace tbrpg.Controllers
         /// <summary>
         /// Raises the <see cref="AdventureLoaded"/> event.
         /// </summary>
-        private void OnAdventureLoaded()
-        {
-            this.AdventureLoaded?.Invoke(this, new EventArgs());
-        }
+        private void OnAdventureLoaded() => this.AdventureLoaded?.Invoke(this, new EventArgs());
 
         /// <summary>
         /// Saves the <see cref="ActiveAdventure"/> to the specified storage location.
@@ -136,18 +133,7 @@ namespace tbrpg.Controllers
         /// <summary>
         /// Raises the <see cref="AdventureSaved"/> event.
         /// </summary>
-        private void OnAdventureSaved()
-        {
-            this.AdventureSaved?.Invoke(this, new EventArgs());
-        }
-
-        /// <summary>
-        /// Raises the <see cref="AdventureSaved"/> event.
-        /// </summary>
-        private void OnAdventureStarted()
-        {
-            this.AdventureStarted?.Invoke(this, new EventArgs());
-        }
+        private void OnAdventureSaved() => this.AdventureSaved?.Invoke(this, new EventArgs());
 
         /// <summary>
         /// Starts the active <see cref="Adventure"/>.
@@ -163,5 +149,10 @@ namespace tbrpg.Controllers
                 throw new InvalidOperationException("There is no active Adventure. Did you call LoadAdventure or SetActiveAdventure first?");
             }
         }
+
+        /// <summary>
+        /// Raises the <see cref="AdventureStarted"/> event.
+        /// </summary>
+        private void OnAdventureStarted() => this.AdventureStarted?.Invoke(this, new EventArgs());
     }
 }

--- a/src/tbrpg.CoreRules/AbilityType.cs
+++ b/src/tbrpg.CoreRules/AbilityType.cs
@@ -6,10 +6,10 @@
     public enum AbilityType
     {
         Strength,
-        Intelligence,
-        Wisdom,
         Dexterity,
         Constitution,
+        Intelligence,
+        Wisdom,
         Charisma
     }
 }

--- a/src/tbrpg.CoreRules/Being.cs
+++ b/src/tbrpg.CoreRules/Being.cs
@@ -41,7 +41,7 @@ namespace tbrpg.CoreRules
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets this Being's <see cref="CharacterClass"/>.
+        /// Gets or sets the Being's <see cref="CharacterClass"/>.
         /// </summary>
         /// <remarks>This can be a player character class or a monster type.</remarks>
         public CharacterClass Class { get; set; }
@@ -52,7 +52,7 @@ namespace tbrpg.CoreRules
         public Alignment Alignment { get; set; }
 
         /// <summary>
-        /// Gets or sets this Being's <see cref="Ability"/> collection.
+        /// Gets or sets the Being's <see cref="Ability"/> collection.
         /// </summary>
         public List<Ability> Abilities { get; set; }
 
@@ -73,12 +73,12 @@ namespace tbrpg.CoreRules
         public int ExperiencePoints { get; set; }
 
         /// <summary>
-        /// Gets whether this Being is alive (has greater than zero hit points).
+        /// Gets whether the Being is alive (has greater than zero hit points).
         /// </summary>
         public bool IsAlive => HitPoints > 0;
 
         /// <summary>
-        /// Gets or sets whether this Being can be attacked.
+        /// Gets or sets whether the Being can be attacked.
         /// </summary>
         public bool IsTargetable { get; set; }
 

--- a/src/tbrpg.CoreRules/BeingTargetingEventArgs.cs
+++ b/src/tbrpg.CoreRules/BeingTargetingEventArgs.cs
@@ -1,8 +1,8 @@
 ﻿namespace tbrpg.CoreRules
 {
     /// <summary>
-    /// Provides information for events in which one Being is targeting another. This is
-    /// typically done prior to performing a <see cref="GameAction"/>.
+    /// Provides information for events in which one Being is targeting another.
+    /// Such events are typically fired prior to performing a <see cref="GameAction"/>.
     /// </summary>
     public class BeingTargetingEventArgs
     {

--- a/src/tbrpg.CoreRules/Dungeon.cs
+++ b/src/tbrpg.CoreRules/Dungeon.cs
@@ -56,12 +56,13 @@ namespace tbrpg.CoreRules
         /// </summary>
         /// <param name="x">The position on the x axis.</param>
         /// <param name="y">The position on the y axis.</param>
+        /// <param name="z">The position on the z axis. Default: <c>0</c>.</param>
         /// <returns>The new <see cref="GamePosition"/> of the <see cref="Party"/>.</returns>
         /// <remarks>To determine whether the party moves to a position occupied by an encounter, subscribe to
         /// the <see cref="Encountered"/> event.</remarks>
-        public GamePosition MoveParty(int x, int y)
+        public GamePosition MoveParty(int x, int y, int z = 0)
         {
-            this.CurrentPosition = new GamePosition(x, y);
+            this.CurrentPosition = new GamePosition(x, y, z);
 
             // Check Encounters to see if there is an Encounter at this position
             Encounter enc = this.Encounters.Find(e => e.Position.Equals(this.CurrentPosition));

--- a/src/tbrpg.CoreRules/Encounter.cs
+++ b/src/tbrpg.CoreRules/Encounter.cs
@@ -48,12 +48,12 @@ namespace tbrpg.CoreRules
         public Party AdventuringParty { get; private set; }
 
         /// <summary>
-        /// Gets whether this Encounter has been started.
+        /// Gets whether the Encounter has been started.
         /// </summary>
         public bool IsEncounterStarted { get; private set; }
 
         /// <summary>
-        /// Gets whether this Encounter has been completed.
+        /// Gets whether the Encounter has been completed.
         /// </summary>
         public bool IsEncounterEnded { get; private set; }
 
@@ -68,7 +68,7 @@ namespace tbrpg.CoreRules
         /// </summary>
         /// <param name="adventurers">The <see cref="Party"/> of adventurers to act upon the <see cref="EncounterParty"/> in this <see cref="Encounter"/>.</param>
         /// <param name="startEncounter">Specifies whether the Encounter should be started immediately upon adding the adventuring party. Default: <c>false</c>.</param>
-        public void SetAdventuringParty(Party adventurers, bool startEncounter = false)
+        public void SetAdventuringParty(Party adventurers)
         {
             if (this.AdventuringParty == null)
             {
@@ -77,11 +77,6 @@ namespace tbrpg.CoreRules
             else
             {
                 throw new InvalidOperationException("An adventuring party has already been added to this Encounter.");
-            }
-
-            if (startEncounter)
-            {
-                StartEncounter();
             }
         }
 

--- a/src/tbrpg.CoreRules/IGameItem.cs
+++ b/src/tbrpg.CoreRules/IGameItem.cs
@@ -3,8 +3,8 @@
     /// <summary>
     /// Specification defining any object that can appear in the game world that is not an <see cref="IGamePiece"/>.
     /// </summary>
-    /// <remarks>A class implementing the IGameItem interface indicates that the object can potentially be wielded
-    /// as an active item by a <see cref="IGamePiece"/>, such as a weapon or spell.</remarks>
+    /// <remarks>A class implementing this interface indicates that the object can be wielded
+    /// as an active item by an <see cref="IGamePiece"/>, such as a weapon or spell.</remarks>
     public interface IGameItem
     {
         /// <summary>
@@ -27,7 +27,7 @@
         /// </summary>
         /// <returns>The amount of damage rolled.</returns>
         int GetDamageRoll();
-        
+
         /// <summary>
         /// Specifies the number of <see cref="IGamePiece"/>s that can be targeted when this IGameItem is wielded as a weapon.
         /// </summary>

--- a/src/tbrpg.Tests/CoreRulesTests.cs
+++ b/src/tbrpg.Tests/CoreRulesTests.cs
@@ -10,7 +10,7 @@ namespace tbrpg.Tests
         [Fact]
         public void InitMajorGameEntities()
         {
-            // TODO: This is not exactly a "unit test." Should break these out
+            // TODO: This isn't really a "unit test." Should break these out
             // TODO: into their own methods, and perhaps use a playlist to execute
             // TODO: them in order, populating member fields of this test class
             // TODO: and referencing those in downstream tests.
@@ -45,11 +45,11 @@ namespace tbrpg.Tests
         public void ExecuteAdventureBattle()
         {
             // Get fully initialized GameManager (from InitGameSystemModel?)
-            // Get Encounter from active Adventure, active Dungeon
-            // Set active Encounter (on Dungeon? on GameManager?)
-            // Set autobattle ON (this is on the Encounter, but where best to set?)
-            // Add active Adventure party to active Encounter
-            // Perform battle
+            // Set autobattle ON (this is on the Encounter, but where best to set? Probably at the Adventure level - maybe need an AdventureSettings class)
+            // Set active Party for Adventure
+            // Set active Dungeon for the Adventure
+            // Move Party to Encounter location
+            // Perform (auto) battle
 
             Assert.NotNull("Test not yet implemented.");
         }
@@ -78,8 +78,9 @@ namespace tbrpg.Tests
                 Assert.True(enc.IsEncounterEnded);
             };
 
-            // Add the adventuring party and specify AutoBattle = true
-            encounter.SetAdventuringParty(playerParty, true);
+            // Add the adventuring party and start the battle
+            encounter.SetAdventuringParty(playerParty);
+            encounter.StartEncounter();
         }
     }
 }

--- a/src/tbrpg.Tests/SaveLoadTests.cs
+++ b/src/tbrpg.Tests/SaveLoadTests.cs
@@ -9,10 +9,10 @@ namespace tbrpg.Tests
     public class SaveLoadTests
     {
         private string _saveDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        private string _saveFile = "tbrpg_adventure.json";
+        private string _saveFile = "tbrpg-adventure.json";
 
         [Fact]
-        public void SaveLoadAdventureFile()
+        public void SaveAndLoadAdventureFile()
         {
             // Since xUnit runs all tests in parallel, we can't guarantee that the save-to-file test would be
             // completed prior to the load-from-file test, so run them both here so that the load-from-file has
@@ -38,9 +38,9 @@ namespace tbrpg.Tests
             dungeon.Encounters.Add(encounter);
 
             Adventure adventure = new Adventure();
-            adventure.SetActiveParty(PartyGenerator.GetPlayerParty());
             adventure.AddDungeon(dungeon);
             adventure.SetActiveDungeon(dungeon);
+            adventure.SetActiveParty(PartyGenerator.GetPlayerParty());
 
             return adventure;
         }


### PR DESCRIPTION
- more expression bodied members
- comment updating/fixing
- Encounter.SetAdventuringParty now only sets the adventuring party (previously it could also start the battle)
- Dungeon.MoveParty now accepts Z coordinate