### PR TITLE
NuGet package metadata

### DIFF
--- a/src/osrlib.Core/osrlib.Core.csproj
+++ b/src/osrlib.Core/osrlib.Core.csproj
@@ -7,6 +7,21 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!--NuGet package metadata properties https://docs.microsoft.com/dotnet/core/tools/csproj#nuget-metadata-properties -->
+    <PackageId>Osrlib.Net</PackageId>
+    <Version>0.0.1-alpha</Version>
+    <Authors>Marshall Macy II</Authors>
+    <Company>OSRlib.NET</Company>
+    <Title>OSRlib.NET</Title>
+    <PackageDescription>A .NET Core class library in C# for powering turn-based RPGs in the old-school revival (OSR) style.</PackageDescription>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReleaseNotes>Initial NuGet release of OSRlib.NET.</PackageReleaseNotes>
+    <PackageTags>rpg;turn-based;osr;game;engine;bard's tale;dungeons and dragons</PackageTags>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
+    <RepositoryUrl>https://github.com/mmacy/osrlib-dotnet</RepositoryUrl>
+    <!--End NuGet package metadata properties -->
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Preparation step 1 for publishing `.nupkg` to NuGet.org.

This is in prep to resolve issue #54.