### PR TITLE
[build] fix Azure pipeline config

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,10 +6,10 @@
 ################################
 
 trigger:
-- master
+- main
 
 pool:
-  vmImage: 'Ubuntu-16.04'
+  vmImage: 'ubuntu-latest'
 
 variables:
   buildConfiguration: 'Release'


### PR DESCRIPTION
Fixes #63

Updates the Azure Pipelines config file:

- Builds now trigger on pushes to new default `main` branch
- VM image is now `ubuntu-latest`  (was the now-EOLed v16.04)

Before this PR:

```console
##[warning]An image label with the label Ubuntu-16.04 does not exist.
,##[error]The remote provider was unable to process the request.
Pool: Azure Pipelines
Image: Ubuntu-16.04
Started: Today at 6:24 PM
Duration: 9m 30s
```

With changes in this PR:

```console
Pool: Azure Pipelines
Image: ubuntu-latest
Agent: Hosted Agent
Started: Today at 6:39 PM
Duration: 25s

Job preparation parameters
7 queue time variables used
90% tests passed
```