### PR TITLE
Restore support for the NdN dice notation format

### DIFF
--- a/src/osrlib.Core/Dice/DiceHand.cs
+++ b/src/osrlib.Core/Dice/DiceHand.cs
@@ -58,16 +58,22 @@ namespace osrlib.Dice
                 // Sanitize the dice notation
                 diceNotation = DiceUtility.SanitizeDiceNotation(diceNotation);
             }
-            catch (ArgumentException ex)
+            catch (ArgumentException)
             {
                 // Rethrow the exception if it was thrown by SanitizeDiceNotation
-                throw new ArgumentException("Incorrect dice notation format. Use ndn, where n is the number of dice and the number of sides.");
+                throw new ArgumentException("Incorrect dice notation format. Use NdN, where N is first the number of dice and then the number of sides.");
             }
 
             // Split the dice notation into the number of dice and the number of sides
             string[] parts = diceNotation.Split('d');
             int count = int.Parse(parts[0]);
             int sides = int.Parse(parts[1]);
+
+            if (count <= 0)
+            {
+                // Must have at least one (1) die to roll.
+                throw new ArgumentException("Incorrect dice notation format. Use NdN, where N is first the number of dice and then the number of sides.");
+            }
 
             // Set the properties
             DieCount = count;

--- a/src/osrlib.Core/Dice/DiceHand.cs
+++ b/src/osrlib.Core/Dice/DiceHand.cs
@@ -11,24 +11,23 @@ namespace osrlib.Dice
     /// the creation of a DiceRoll. Create a DiceHand, add it to a <see cref="DiceRoll"/>, then
     /// call its <see cref="DiceRoll.RollDice()"/> method to get the result.
     /// </remarks>
-    /// <example>
-    /// <code>
-    /// // Roll one twenty-sided die
-    /// DiceHand hand = new DiceHand(1, DieType.d20);
-    /// DiceRoll roll = new DiceRoll(hand);
-    /// int result = roll.RollDice();
-    /// </code>
-    /// </example>
     public class DiceHand
     {
         /// <summary>
-        /// Creates a new instance of DiceHand, appropriate for passing to the <see cref="DiceRoll"/> constructor.
+        /// Initializes a new instance of the <see cref="DiceHand"/> class using the specified number of dice and sides.
         /// </summary>
-        /// <param name="count">The number of Dice in the DiceHand - the first value in the '#d#' format (the '3' in 3d6).</param>
-        /// <param name="sides">The number of sides per Die in the DiceHand.</param>
+        /// <param name="count">The number of dice in the DiceHand.</param>
+        /// <param name="sides">The number of sides of each die in the DiceHand.</param>
+        /// <example>
+        /// The following example demonstrates how to create a new instance of the <see cref="DiceHand"/> class using two 6-sided dice and pass it to the DiceRoll constructor:
+        /// <code>
+        /// DiceHand diceHand = new DiceHand(2, DieType.d6);
+        /// DiceRoll diceRoll = new DiceRoll(diceHand);
+        /// </code>
+        /// </example>
         public DiceHand(int count, DieType sides)
         {
-            //Perform some validity checks to ensure the count and sides params are at least 0.
+            // Perform some validity checks to ensure the count and sides params are at least 0.
 
             if (count > 0)
             {
@@ -42,6 +41,40 @@ namespace osrlib.Dice
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="DiceHand"/> class using the specified dice notation.
+        /// </summary>
+        /// <param name="diceNotation">The dice notation string, in the format "NdN", where N is a positive integer.</param>
+        /// <example>
+        /// The following example demonstrates how to create a new instance of the <see cref="DiceHand"/> class using the dice notation string "2d6" and pass it to the DiceRoll constructor:
+        /// <code>
+        /// DiceHand diceHand = new DiceHand("2d6");
+        /// DiceRoll diceRoll = new DiceRoll(diceHand);
+        /// </code>
+        /// </example>
+        public DiceHand(string diceNotation)
+        {
+            try
+            {
+                // Sanitize the dice notation
+                diceNotation = DiceUtility.SanitizeDiceNotation(diceNotation);
+            }
+            catch (ArgumentException ex)
+            {
+                // Rethrow the exception if it was thrown by SanitizeDiceNotation
+                throw new ArgumentException("Incorrect dice notation format. Use ndn, where n is the number of dice and the number of sides.");
+            }
+
+            // Split the dice notation into the number of dice and the number of sides
+            string[] parts = diceNotation.Split('d');
+            int count = int.Parse(parts[0]);
+            int sides = int.Parse(parts[1]);
+
+            // Set the properties
+            DieCount = count;
+            DieSides = (DieType)sides;
+        }
+
+        /// <summary>
         /// Gets or sets the number of dice in the DiceHand.
         /// </summary>
         public int DieCount { get; set; }
@@ -51,4 +84,5 @@ namespace osrlib.Dice
         /// </summary>
         public DieType DieSides { get; set; }
     }
+
 }

--- a/src/osrlib.Core/Dice/DiceUtility.cs
+++ b/src/osrlib.Core/Dice/DiceUtility.cs
@@ -28,15 +28,11 @@ namespace osrlib.Dice
         /// </example>
         public static string SanitizeDiceNotation(string diceNotation)
         {
-            // Use a regular expression to match the required format
-            Regex regex = new Regex(@"^[0-9]*d[0-9]+$");
+            // Regular expression matching the required NdN format
+            Regex regex = new Regex(@"^([1-9]\d{0,2})d([1-9]\d{0,1})$");
 
             // Convert the input to lowercase
             diceNotation = diceNotation.ToLowerInvariant();
-
-            // Remove any invalid characters and whitespace from the string
-            diceNotation = Regex.Replace(diceNotation, @"[^0-9d]", string.Empty);
-            diceNotation = diceNotation.Trim();
 
             // If the input is just "dN", add a "1" to the beginning to make it "1dN"
             if (diceNotation.StartsWith("d"))
@@ -44,11 +40,25 @@ namespace osrlib.Dice
                 diceNotation = "1" + diceNotation;
             }
 
+            // Remove any invalid characters and whitespace from the string
+            diceNotation = Regex.Replace(diceNotation, @"[^0-9d]", string.Empty);
+            diceNotation = diceNotation.Trim();
+
             // Check that the string matches the required format
             if (!regex.IsMatch(diceNotation))
             {
                 throw new ArgumentException(
                     "Incorrect dice notation format. Use NdN, where N is first the number of dice and then the number of sides.");
+            }
+
+            // Get the number of sides in the dice notation
+            int sides = int.Parse(diceNotation.Split('d')[1]);
+
+            // Check that the number of sides is one of the values in the DieType enum
+            if (!Enum.IsDefined(typeof(DieType), sides))
+            {
+                throw new ArgumentException(
+                    $"Invalid number of sides. Must be one of the values in the {nameof(DieType)} enum.");
             }
 
             return diceNotation;

--- a/src/osrlib.Core/Dice/DiceUtility.cs
+++ b/src/osrlib.Core/Dice/DiceUtility.cs
@@ -26,7 +26,6 @@ namespace osrlib.Dice
         /// diceNotation = osrlib.Dice.DiceUtility.SanitizeDiceNotation(diceNotation);
         /// </code>
         /// </example>
-
         public static string SanitizeDiceNotation(string diceNotation)
         {
             // Use a regular expression to match the required format

--- a/src/osrlib.Core/Dice/DiceUtility.cs
+++ b/src/osrlib.Core/Dice/DiceUtility.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Text.RegularExpressions;
+
+
+namespace osrlib.Dice
+{
+    /// <summary>
+    /// Provides utility methods for working with dice notation strings.
+    /// </summary>
+    public static class DiceUtility
+    {
+        /// <summary>
+        /// Sanitizes the input string to ensure it is in the correct format "NdN" or "dN".
+        /// </summary>
+        /// <param name="diceNotation">The input string to sanitize.</param>
+        /// <returns>The sanitized input string in the standardized "NdN" format, even if the original input was in the "dN" format.</returns>
+        /// <example>
+        /// The following example demonstrates the use of the SanitizeDiceNotation method:
+        /// <code>
+        /// string diceNotation = "2d6";
+        /// diceNotation = osrlib.Dice.DiceUtility.SanitizeDiceNotation(diceNotation);
+        /// </code>
+        /// The following example demonstrates the use of the SanitizeDiceNotation method for the "dN" format:
+        /// <code>
+        /// string diceNotation = "d6";
+        /// diceNotation = osrlib.Dice.DiceUtility.SanitizeDiceNotation(diceNotation);
+        /// </code>
+        /// </example>
+
+        public static string SanitizeDiceNotation(string diceNotation)
+        {
+            // Use a regular expression to match the required format
+            Regex regex = new Regex(@"^[0-9]*d[0-9]+$");
+
+            // Convert the input to lowercase
+            diceNotation = diceNotation.ToLowerInvariant();
+
+            // Remove any invalid characters and whitespace from the string
+            diceNotation = Regex.Replace(diceNotation, @"[^0-9d]", string.Empty);
+            diceNotation = diceNotation.Trim();
+
+            // If the input is just "dN", add a "1" to the beginning to make it "1dN"
+            if (diceNotation.StartsWith("d"))
+            {
+                diceNotation = "1" + diceNotation;
+            }
+
+            // Check that the string matches the required format
+            if (!regex.IsMatch(diceNotation))
+            {
+                throw new ArgumentException(
+                    "Incorrect dice notation format. Use NdN, where N is first the number of dice and then the number of sides.");
+            }
+
+            return diceNotation;
+        }
+    }
+}

--- a/src/osrlib.Core/Dice/DieType.cs
+++ b/src/osrlib.Core/Dice/DieType.cs
@@ -3,7 +3,7 @@
 /// </summary>
 public enum DieType
 {
-    /// <summary>One-sided die.</summary>
+    /// <summary>Single-sided die.</summary>
     d1 = 1,
     /// <summary>Two-sided die.</summary>
     d2 = 2,
@@ -19,6 +19,6 @@ public enum DieType
     d12 = 12,
     /// <summary>Twenty-sided die.</summary>
     d20 = 20,
-    /// <summary>One-hundred-sided die.</summary>
+    /// <summary>Percentage die.</summary>
     d100 = 100
 }

--- a/src/osrlib.Tests/DiceTests.cs
+++ b/src/osrlib.Tests/DiceTests.cs
@@ -51,9 +51,10 @@ namespace osrlib.Tests
         }
 
         [Theory]
-        [InlineData("2d0", "Incorrect dice notation format. Use ndn, where n is the number of dice and the number of sides.")]
-        [InlineData("2d", "Incorrect dice notation format. Use ndn, where n is the number of dice and the number of sides.")]
-        [InlineData("abc", "Incorrect dice notation format. Use ndn, where n is the number of dice and the number of sides.")]
+        [InlineData("d0", "Incorrect dice notation format. Use NdN, where N is first the number of dice and then the number of sides.")]
+        [InlineData("2d0", "Incorrect dice notation format. Use NdN, where N is first the number of dice and then the number of sides.")]
+        [InlineData("2d",  "Incorrect dice notation format. Use NdN, where N is first the number of dice and then the number of sides.")]
+        [InlineData("abc", "Incorrect dice notation format. Use NdN, where N is first the number of dice and then the number of sides.")]
         public void DiceHand_StringConstructor_ThrowsArgumentException_WhenDiceNotationIsInvalid(string diceNotation, string expectedMessage)
         {
             // Act
@@ -122,6 +123,19 @@ namespace osrlib.Tests
             Assert.Equal("2d6", result);
         }
 
+        [Theory]
+        [InlineData("2d")]
+        [InlineData("2d6d8")]
+        [InlineData("2d6d")]
+        [InlineData("2 ")]
+        [InlineData("^&$#^&#$&*(#@)~")]
+        [InlineData("02d6")]
+        public void SanitizeDiceNotation_InvalidInput_ThrowsArgumentException(string diceNotation)
+        {
+            // Act and Assert
+            Assert.Throws<ArgumentException>(() => DiceUtility.SanitizeDiceNotation(diceNotation));
+        }
+
         [Fact]
         public void SanitizeDiceNotation_SingleDieFormat_ReturnsExpectedResult()
         {
@@ -133,18 +147,6 @@ namespace osrlib.Tests
 
             // Assert
             Assert.Equal("1d6", result);
-        }
-
-        [Theory]
-        [InlineData("2d")]
-        [InlineData("2d6d8")]
-        [InlineData("2d6d")]
-        [InlineData("2 ")]
-        [InlineData("^&$#^&#$&*(#@)~")]
-        public void SanitizeDiceNotation_InvalidInput_ThrowsArgumentException(string diceNotation)
-        {
-            // Act and Assert
-            Assert.Throws<ArgumentException>(() => DiceUtility.SanitizeDiceNotation(diceNotation));
         }
 
     }

--- a/src/osrlib.Tests/DiceTests.cs
+++ b/src/osrlib.Tests/DiceTests.cs
@@ -46,5 +46,45 @@ namespace osrlib.Tests
 
             Exception ex = Assert.Throws<ArgumentException>(() => new DiceHand(numDie, dieType));
         }
+
+
+        [Fact]
+        public void SanitizeDiceNotation_ValidInput_ReturnsExpectedResult()
+        {
+            // Arrange
+            string diceNotation = " 2d6 ";
+
+            // Act
+            string result = DiceUtility.SanitizeDiceNotation(diceNotation);
+
+            // Assert
+            Assert.Equal("2d6", result);
+        }
+
+        [Fact]
+        public void SanitizeDiceNotation_SingleDieFormat_ReturnsExpectedResult()
+        {
+            // Arrange
+            string diceNotation = "d6";
+
+            // Act
+            string result = DiceUtility.SanitizeDiceNotation(diceNotation);
+
+            // Assert
+            Assert.Equal("1d6", result);
+        }
+
+        [Theory]
+        [InlineData("2d")]
+        [InlineData("2d6d8")]
+        [InlineData("2d6d")]
+        [InlineData("2 ")]
+        [InlineData("^&$#^&#$&*(#@)~")]
+        public void SanitizeDiceNotation_InvalidInput_ThrowsArgumentException(string diceNotation)
+        {
+            // Act and Assert
+            Assert.Throws<ArgumentException>(() => DiceUtility.SanitizeDiceNotation(diceNotation));
+        }
+
     }
 }

--- a/src/osrlib.Tests/DiceTests.cs
+++ b/src/osrlib.Tests/DiceTests.cs
@@ -6,35 +6,96 @@ namespace osrlib.Tests
 {
     public class DiceTests
     {
+        [Fact]
+        public void DiceHand_IntConstructor_ReturnsExpectedResult()
+        {
+            // Arrange
+            int count = 2;
+            DieType sides = DieType.d6;
+
+            // Act
+            var diceHand = new DiceHand(count, sides);
+
+            // Assert
+            Assert.Equal(count, diceHand.DieCount);
+            Assert.Equal(sides, diceHand.DieSides);
+        }
+
+        [Fact]
+        public void DiceHand_StringConstructor_ReturnsExpectedResult()
+        {
+            // Arrange
+            string diceNotation = "2d6";
+
+            // Act
+            var diceHand = new DiceHand(diceNotation);
+
+            // Assert
+            Assert.Equal(2, diceHand.DieCount);
+            Assert.Equal(DieType.d6, diceHand.DieSides);
+        }
+
+        [Theory]
+        [InlineData(0, "The count parameter (number of dice) must be equal to or greater than 1.")]
+        [InlineData(-2, "The count parameter (number of dice) must be equal to or greater than 1.")]
+        public void DiceHand_IntConstructor_ThrowsArgumentException_WhenCountIsInvalid(int count, string expectedMessage)
+        {
+            // Arrange
+            DieType sides = DieType.d6;
+
+            // Act
+            var exception = Assert.Throws<ArgumentException>(() => new DiceHand(count, sides));
+
+            // Assert
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData("2d0", "Incorrect dice notation format. Use ndn, where n is the number of dice and the number of sides.")]
+        [InlineData("2d", "Incorrect dice notation format. Use ndn, where n is the number of dice and the number of sides.")]
+        [InlineData("abc", "Incorrect dice notation format. Use ndn, where n is the number of dice and the number of sides.")]
+        public void DiceHand_StringConstructor_ThrowsArgumentException_WhenDiceNotationIsInvalid(string diceNotation, string expectedMessage)
+        {
+            // Act
+            var exception = Assert.Throws<ArgumentException>(() => new DiceHand(diceNotation));
+
+            // Assert
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
         /// <summary>
         /// Ensures that the <see cref="DiceRoll"/> always returns values within the desired range.
         /// </summary>
         [Fact]
-        public void DiceRollsAlwaysWithinBounds()
+        public void DiceRolls_ShouldAlwaysBeWithinBounds()
         {
+            // Arrange
             int numRolls = 1000;
 
+            // Test for numDie = 1, dieType = d20
             int numDie = 1;
             DieType dieType = DieType.d20;
             DiceHand hand = new DiceHand(numDie, dieType);
             DiceRoll roll = new DiceRoll(hand);
-            int result;
+
+            // Act and Assert
             for (int i = 0; i < numRolls; i++)
             {
-                result = roll.RollDice();
-                Assert.True(result >= numDie);
-                Assert.True(result <= numDie * (int)dieType);
+                int result = roll.RollDice();
+                Assert.InRange(result, numDie, numDie * (int)dieType);
             }
 
+            // Test for numDie = 2, dieType = d10
             numDie = 2;
             dieType = DieType.d10;
             hand = new DiceHand(numDie, dieType);
             roll = new DiceRoll(hand);
+
+            // Act and Assert
             for (int i = 0; i < numRolls; i++)
             {
-                result = roll.RollDice();
-                Assert.True(result >= numDie);
-                Assert.True(result <= numDie * (int)dieType);
+                int result = roll.RollDice();
+                Assert.InRange(result, numDie, numDie * (int)dieType);
             }
         }
 

--- a/src/osrlib.Tests/SaveLoadTests.cs
+++ b/src/osrlib.Tests/SaveLoadTests.cs
@@ -8,10 +8,14 @@ namespace osrlib.Tests
 {
 
     [Collection("SaveLoadTests")]
-    public class SaveLoadTests
+    [TestCaseOrderer("osrlib.Tests.PriorityOrderer", "osrlib.Tests")]
+    public class SaveLoadTests //: IDisposable
     {
-        private string _saveDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        private string _saveFile = "tbrpg-adventure.json";
+        private static string _saveDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        private static string _saveFile = "tbrpg-adventure.json";
+        private static string _savePath = Path.Combine(_saveDir, _saveFile);
+
+        private bool _disposed;
 
         [Fact, TestPriority(1)]
         public void SaveAdventureFile_ShouldSucceed()
@@ -20,23 +24,31 @@ namespace osrlib.Tests
             Adventure adventure = GetInitializedAdventure();
 
             // Act
-            bool result = SaveLoadLocal.Save(adventure, Path.Combine(_saveDir, _saveFile));
+            bool fileWritten = SaveLoadLocal.Save(adventure, _savePath);
+
+            if (fileWritten)
+            {
+                Console.WriteLine($"File successfully written to " + _savePath);
+            }
 
             // Assert
-            Assert.True(result);
+            Assert.True(fileWritten);
         }
 
         [Fact, TestPriority(2)]
         public void LoadAdventureFile_ShouldSucceed()
         {
-            // Arrange
-            string savePath = Path.Combine(_saveDir, _saveFile);
-
             // Act
-            Adventure loadedAdventure = SaveLoadLocal.Load(savePath);
+            Adventure loadedAdventure = SaveLoadLocal.Load(_savePath);
 
             // Assert
             Assert.NotNull(loadedAdventure);
+
+            // Clean up
+            if (File.Exists(_savePath))
+            {
+                File.Delete(_savePath);
+            }
         }
 
         private Adventure GetInitializedAdventure()

--- a/src/osrlib.Tests/SaveLoadTests.cs
+++ b/src/osrlib.Tests/SaveLoadTests.cs
@@ -6,22 +6,36 @@ using osrlib.Core;
 
 namespace osrlib.Tests
 {
+
+    [Collection("SaveLoadTests")]
     public class SaveLoadTests
     {
         private string _saveDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         private string _saveFile = "tbrpg-adventure.json";
 
-        [Fact]
-        public void SaveAndLoadAdventureFile()
+        [Fact, TestPriority(1)]
+        public void SaveAdventureFile_ShouldSucceed()
         {
-            // Since xUnit runs all tests in parallel, we can't guarantee that the save-to-file test would be
-            // completed prior to the load-from-file test, so run them both here so that the load-from-file has
-            // a file to load.
-
+            // Arrange
             Adventure adventure = GetInitializedAdventure();
-            Assert.True(SaveLoadLocal.Save(adventure, Path.Combine(_saveDir, _saveFile)));
 
-            Adventure loadedAdventure = SaveLoadLocal.Load(Path.Combine(_saveDir, _saveFile));
+            // Act
+            bool result = SaveLoadLocal.Save(adventure, Path.Combine(_saveDir, _saveFile));
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact, TestPriority(2)]
+        public void LoadAdventureFile_ShouldSucceed()
+        {
+            // Arrange
+            string savePath = Path.Combine(_saveDir, _saveFile);
+
+            // Act
+            Adventure loadedAdventure = SaveLoadLocal.Load(savePath);
+
+            // Assert
             Assert.NotNull(loadedAdventure);
         }
 

--- a/src/osrlib.Tests/SaveLoadTests.cs
+++ b/src/osrlib.Tests/SaveLoadTests.cs
@@ -15,8 +15,6 @@ namespace osrlib.Tests
         private static string _saveFile = "tbrpg-adventure.json";
         private static string _savePath = Path.Combine(_saveDir, _saveFile);
 
-        private bool _disposed;
-
         [Fact, TestPriority(1)]
         public void SaveAdventureFile_ShouldSucceed()
         {

--- a/src/osrlib.Tests/TestUtility.cs
+++ b/src/osrlib.Tests/TestUtility.cs
@@ -65,9 +65,17 @@ namespace osrlib.Tests
         private static TValue GetOrCreate<TKey, TValue>(
             IDictionary<TKey, TValue> dictionary, TKey key)
             where TKey : struct
-            where TValue : new() =>
-            dictionary.TryGetValue(key, out TValue? result)
-                ? result
-                : (dictionary[key] = new TValue());
+            where TValue : new()
+        {
+            TValue result;
+            if (dictionary.TryGetValue(key, out result))
+            {
+                return result;
+            }
+
+            result = new TValue();
+            dictionary[key] = result;
+            return result;
+        }
     }
 }

--- a/src/osrlib.Tests/TestUtility.cs
+++ b/src/osrlib.Tests/TestUtility.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace osrlib.Tests
+{
+    // Adapted from https://learn.microsoft.com/dotnet/core/testing/order-unit-tests?pivots=xunit
+
+    /// <summary>
+    /// The TestPriorityAttribute is used to specify the priority of a test case.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class TestPriorityAttribute : Attribute
+    {
+        public int Priority { get; private set; }
+
+        public TestPriorityAttribute(int priority) => Priority = priority;
+    }
+
+    /// <summary>
+    /// The PriorityOrderer is used to order test cases based on their priority.
+    /// </summary>
+    public class PriorityOrderer : ITestCaseOrderer
+    {
+        /// <summary>
+        /// Orders the test cases based on their priority.
+        /// </summary>
+        /// <typeparam name="TTestCase">The type of the test case.</typeparam>
+        /// <param name="testCases">The test cases to be ordered.</param>
+        /// <returns>The ordered test cases.</returns>
+        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(
+            IEnumerable<TTestCase> testCases) where TTestCase : ITestCase
+        {
+            string assemblyName = typeof(TestPriorityAttribute).AssemblyQualifiedName!;
+            var sortedMethods = new SortedDictionary<int, List<TTestCase>>();
+            foreach (TTestCase testCase in testCases)
+            {
+                int priority = testCase.TestMethod.Method
+                    .GetCustomAttributes(assemblyName)
+                    .FirstOrDefault()
+                    ?.GetNamedArgument<int>(nameof(TestPriorityAttribute.Priority)) ?? 0;
+
+                GetOrCreate(sortedMethods, priority).Add(testCase);
+            }
+
+            foreach (TTestCase testCase in
+                sortedMethods.Keys.SelectMany(
+                    priority => sortedMethods[priority].OrderBy(
+                        testCase => testCase.TestMethod.Method.Name)))
+            {
+                yield return testCase;
+            }
+        }
+
+        /// <summary>
+        /// Gets the value associated with the specified key, or creates a new value if the key is not found.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        /// <param name="dictionary">The dictionary.</param>
+        /// <param name="key">The key.</param>
+        /// <returns>The value associated with the specified key.</returns>
+        private static TValue GetOrCreate<TKey, TValue>(
+            IDictionary<TKey, TValue> dictionary, TKey key)
+            where TKey : struct
+            where TValue : new() =>
+            dictionary.TryGetValue(key, out TValue? result)
+                ? result
+                : (dictionary[key] = new TValue());
+    }
+}


### PR DESCRIPTION
Brings back the support for creating a DiceHand by using the NdN-format string, for example `3d6` or `1d20`.

Also adds unit tests for same and refactors a few tests to adhere to the `Arrange`, `Act`, `Assert` paradigm (and makes them actual unit tests).