### PR TITLE
[ISS-22] Quest system - part 1 of 2

### DIFF
--- a/src/osrlib.Core/Engine/CharacterClass.cs
+++ b/src/osrlib.Core/Engine/CharacterClass.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 
 namespace osrlib.Core.Engine
 {
@@ -92,7 +90,6 @@ namespace osrlib.Core.Engine
                 }
             }
         }
-
         
         /// <summary>
         /// Gets the experience point progression for the character class.

--- a/src/osrlib.Core/Engine/Quest.cs
+++ b/src/osrlib.Core/Engine/Quest.cs
@@ -1,14 +1,91 @@
-﻿namespace osrlib.Core.Engine
+﻿/// <summary>
+/// Represents a quest in a game, which consists of multiple quest pieces that can be obtained. A quest is completed only when all its required pieces are obtained.
+/// </summary>
+/// <remarks>
+/// This class allows tracking of the quest status and provides an event that notifies subscribers when the quest is completed. Pieces should be added to a quest using the constructor.
+/// </remarks>
+/// <example>
+/// This sample shows how to create an instance of the Quest class and subscribe to the QuestCompleted event.
+/// <code>
+/// QuestPiece piece1 = new QuestPiece("1", "Piece 1", true);
+/// QuestPiece piece2 = new QuestPiece("2", "Piece 2", false);
+/// Quest quest = new Quest(1, "Quest 1", "This is a quest.", new List&lt;QuestPiece&gt; { piece1, piece2 });
+/// 
+/// quest.QuestCompleted += () => Console.WriteLine("Quest completed!");
+/// </code>
+/// </example>
+public class Quest
 {
     /// <summary>
-    /// The Quest is associated with one <see cref="Adventure"/>, and one or more <see cref="Dungeon"/> objects.
+    /// Initializes a new instance of the <see cref="Quest"/> class with specified ID, name, and optional description and pieces.
+    /// </summary>
+    /// <param name="id">The ID of the quest.</param>
+    /// <param name="name">The name of the quest.</param>
+    /// <param name="description">The description of the quest. Defaults to an empty string if not provided.</param>
+    /// <param name="pieces">The list of pieces for this quest. Defaults to an empty list if not provided.</param>
+    public Quest(int id, string name, string description = "", List<QuestPiece> pieces = null)
+    {
+        Id = id;
+        Name = name;
+        Description = description;
+        Pieces = pieces ?? new List<QuestPiece>();
+
+        foreach (var piece in Pieces)
+        {
+            piece.StatusChanged += OnQuestPieceStatusChanged;
+        }
+    }
+
+    /// <summary>
+    /// Gets the ID of the quest.
+    /// </summary>
+    public int Id { get; init; }
+
+    /// <summary>
+    /// Gets the name of the quest.
+    /// </summary>
+    public string Name { get; init; }
+
+    /// <summary>
+    /// Gets the description of the quest.
+    /// </summary>
+    public string Description { get; init; }
+
+    /// <summary>
+    /// Gets the list of pieces of the quest.
+    /// </summary>
+    public List<QuestPiece> Pieces { get; }
+
+    /// <summary>
+    /// Event triggered when all required pieces of the quest are obtained.
     /// </summary>
     /// <remarks>
-    /// This class is NOT YET IMPLEMENTED.
+    /// This event can be used to track the completion of the quest and to trigger further actions when the quest is completed.
     /// </remarks>
-    public class Quest
+    public event Action QuestCompleted;
+
+    /// <summary>
+    /// Gets the status of the quest.
+    /// </summary>
+    /// <remarks>
+    /// The status is determined based on the statuses of the quest's pieces: if all required pieces are obtained, the quest is completed; 
+    /// if at least one piece is obtained, the quest is in progress; otherwise, the quest is not started.
+    /// </remarks>
+    public QuestStatus Status =>
+        Pieces.Where(p => p.IsRequired).All(p => p.Status == QuestPieceStatus.Obtained) ? QuestStatus.Completed :
+        Pieces.Any(p => p.Status == QuestPieceStatus.Obtained) ? QuestStatus.InProgress :
+        QuestStatus.NotStarted;
+
+    private void OnQuestPieceStatusChanged(QuestPiece piece, QuestPieceStatus oldStatus, QuestPieceStatus newStatus)
     {
-        //TODO: QuestPiece collection?
-        //TODO: Quests have: an order, a reward (treasure, XP), unlock access to other quests?
+        // Only need to check if the quest is completed when a piece is obtained
+        if (newStatus == QuestPieceStatus.Obtained)
+        {
+            // If all required pieces have been obtained, the quest is completed
+            if (Pieces.Where(p => p.IsRequired).All(p => p.Status == QuestPieceStatus.Obtained))
+            {
+                QuestCompleted?.Invoke();
+            }
+        }
     }
 }

--- a/src/osrlib.Core/Engine/QuestPiece.cs
+++ b/src/osrlib.Core/Engine/QuestPiece.cs
@@ -1,0 +1,83 @@
+/// <summary>
+/// Represents a quest piece in the game.
+/// </summary>
+public class QuestPiece
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuestPiece"/> class.
+    /// </summary>
+    /// <param name="id">The ID of the quest piece.</param>
+    /// <param name="name">The name of the quest piece.</param>
+    /// <param name="isRequired">Whether the quest piece is required to complete the quest.</param>
+    /// <param name="description">The description of the quest piece. Defaults to an empty string if not provided.</param>
+    /// <param name="status">The initial status of the quest piece. Defaults to <see cref="QuestPieceStatus.NotObtained"/> if not provided.</param>
+    public QuestPiece(string id, string name, bool isRequired, string description = "", QuestPieceStatus status = QuestPieceStatus.NotObtained)
+    {
+        Id = id;
+        Name = name;
+        Description = description;
+        IsRequired = isRequired;
+        Status = status;
+    }
+    
+    /// <summary>
+    /// Gets the ID of the quest piece.
+    /// </summary>
+    public string Id { get; init; }
+
+    /// <summary>
+    /// Gets the name of the quest piece.
+    /// </summary>
+    public string Name { get; init; }
+
+    /// <summary>
+    /// Gets the description of the quest piece.
+    /// </summary>
+    public string Description { get; init; }
+
+    /// <summary>
+    /// Indicates whether this quest piece is required to complete the quest.
+    /// </summary>
+    public bool IsRequired { get; }
+
+    private QuestPieceStatus _status;
+
+    /// <summary>
+    /// Gets or sets the status of this quest piece.
+    /// </summary>
+    public QuestPieceStatus Status
+    {
+        get => _status;
+        set
+        {
+            if (_status != value)
+            {
+                var oldStatus = _status;
+                _status = value;
+                StatusChanged?.Invoke(this, oldStatus, _status);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Event triggered when the status of the quest piece changes.
+    /// The event handler receives three arguments:
+    /// - An instance of <see cref="QuestPiece"/>, which represents the quest piece whose status has changed.
+    /// - A value from the <see cref="QuestPieceStatus"/> enumeration representing the old status of the quest piece.
+    /// - A value from the <see cref="QuestPieceStatus"/> enumeration representing the new status of the quest piece.
+    /// </summary>
+    /// <remarks>
+    /// The StatusChanged event can be used to track changes to the quest piece's status in real time, and to trigger further actions when a status change occurs.
+    /// </remarks>
+    /// <example>
+    /// This sample shows how to use the StatusChanged event.
+    /// <code>
+    /// QuestPiece piece = new QuestPiece(1, "Piece 1", "First piece", true, QuestPieceStatus.NotObtained);
+    /// piece.StatusChanged += (qp, oldStatus, newStatus) =>
+    /// {
+    ///     Console.WriteLine($"QuestPiece {qp.Id}: Status changed from {oldStatus} to {newStatus}");
+    /// };
+    /// </code>
+    /// </example>
+    public event Action<QuestPiece, QuestPieceStatus, QuestPieceStatus> StatusChanged;
+}

--- a/src/osrlib.Core/Engine/QuestPieceStatus.cs
+++ b/src/osrlib.Core/Engine/QuestPieceStatus.cs
@@ -1,0 +1,15 @@
+/// <summary>
+/// Represents the status of a quest piece.
+/// </summary>
+public enum QuestPieceStatus
+{
+    /// <summary>
+    /// The quest piece hasn't been found, retrieved, completed, or otherwise been satisfied.
+    /// </summary>
+    NotObtained,
+
+    /// <summary>
+    /// The quest or quest piece has been found, retrieved, completed, or otherwise satisfied.
+    /// </summary>
+    Obtained
+}

--- a/src/osrlib.Core/Engine/QuestStatus.cs
+++ b/src/osrlib.Core/Engine/QuestStatus.cs
@@ -1,0 +1,20 @@
+/// <summary>
+/// Represents the status of a quest.
+/// </summary>
+public enum QuestStatus
+{
+    /// <summary>
+    /// The quest hasn't been started.
+    /// </summary>
+    NotStarted,
+
+    /// <summary>
+    /// The quest has been started, but isn't yet complete.
+    /// </summary>
+    InProgress,
+
+    /// <summary>
+    /// The quest has been completed.
+    /// </summary>
+    Completed
+}

--- a/src/osrlib.Tests/AbilityTests.cs
+++ b/src/osrlib.Tests/AbilityTests.cs
@@ -1,5 +1,3 @@
-using osrlib.Core.Engine;
-
 namespace osrlib.Tests
 {
     public class AbilityTests

--- a/src/osrlib.Tests/QuestTests.cs
+++ b/src/osrlib.Tests/QuestTests.cs
@@ -1,0 +1,97 @@
+namespace osrlib.Tests
+{
+    public class QuestTests
+    {
+        [Fact]
+        public void Quest_IsNotStarted_When_No_Piece_Obtained()
+        {
+            // Arrange
+            var piece1 = new QuestPiece("1", "Piece 1", true);
+            var piece2 = new QuestPiece("2", "Piece 2", true);
+            var quest = new Quest(1, "Quest 1", "This is a quest.", new List<QuestPiece> { piece1, piece2 });
+
+            // Assert
+            Assert.Equal(QuestStatus.NotStarted, quest.Status);
+        }
+
+        [Fact]
+        public void Quest_IsInProgress_When_Any_Piece_Obtained()
+        {
+            // Arrange
+            var piece1 = new QuestPiece("1", "Piece 1", true);
+            var piece2 = new QuestPiece("2", "Piece 2", false);
+            var quest = new Quest(1, "Quest 1", "This is a quest.", new List<QuestPiece> { piece1, piece2 });
+
+            // Act
+            piece2.Status = QuestPieceStatus.Obtained;
+
+            // Assert
+            Assert.Equal(QuestStatus.InProgress, quest.Status);
+        }
+        
+        [Fact]
+        public void Quest_IsCompleted_When_All_Pieces_Obtained()
+        {
+            // Arrange
+            var piece1 = new QuestPiece("1", "Piece 1", true);
+            var piece2 = new QuestPiece("2", "Piece 2", true);
+            var quest = new Quest(1, "Quest 1", "This is a quest.", new List<QuestPiece> { piece1, piece2 });
+
+            // Act
+            piece1.Status = QuestPieceStatus.Obtained;
+            piece2.Status = QuestPieceStatus.Obtained;
+
+            // Assert
+            Assert.Equal(QuestStatus.Completed, quest.Status);
+        }
+
+        [Fact]
+        public void QuestPiece_StatusChanged_Event_Invoked_When_Status_Changed()
+        {
+            // Arrange
+            var piece = new QuestPiece("1", "Piece 1", true);
+            var isStatusChangedTriggered = false;
+            piece.StatusChanged += (qp, oldStatus, newStatus) => isStatusChangedTriggered = true;
+
+            // Act
+            piece.Status = QuestPieceStatus.Obtained;
+
+            // Assert
+            Assert.True(isStatusChangedTriggered);
+        }
+        
+        [Fact]
+        public void QuestCompleted_Event_Is_Invoked_When_All_Required_Pieces_Obtained()
+        {
+            // Arrange
+            var piece1 = new QuestPiece("1", "Piece 1", true);
+            var piece2 = new QuestPiece("2", "Piece 2", false);
+            var quest = new Quest(1, "Quest 1", "This is a quest.", new List<QuestPiece> { piece1, piece2 });
+            var isCompletedTriggered = false;
+            quest.QuestCompleted += () => isCompletedTriggered = true;
+
+            // Act
+            piece1.Status = QuestPieceStatus.Obtained;
+
+            // Assert
+            Assert.True(isCompletedTriggered);
+        }
+
+        [Fact]
+        public void QuestCompleted_Event_Is_Not_Invoked_When_Only_NonRequired_Pieces_Obtained()
+        {
+            // Arrange
+            var piece1 = new QuestPiece("1", "Piece 1", true);
+            var piece2 = new QuestPiece("2", "Piece 2", false);
+            var quest = new Quest(1, "Quest 1", "This is a quest.", new List<QuestPiece> { piece1, piece2 });
+            var isCompletedTriggered = false;
+            quest.QuestCompleted += () => isCompletedTriggered = true;
+
+            // Act
+            piece2.Status = QuestPieceStatus.Obtained;
+
+            // Assert
+            Assert.False(isCompletedTriggered);
+        }
+    }
+}


### PR DESCRIPTION
This is part one of two for the quest system tracked by #22.

## TODO for part 2

- [ ] Provide functionality to allow players to accept or decline a quest their party has been offered or has discovered. For example:
  - [ ] Accept/Decline methods on Quest.
  - [ ] Accepted/Declined events on Quest.
  - [ ] `Adventure`.`Quests` collection and management thereof
  - [ ] ...and more?

> **Note**
> Quests aren't always offered and bestowed by NPCs; a quest could be a property of another game object like a map, a "boss" monster they've killed, or even a dungeon location they traverse.